### PR TITLE
8 error when reading package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sigmaepsilon.core"
-version = "1.1.0"
+version = "1.1.1"
 description = "Common developer utilities for Python projects."
 classifiers=[
         "Development Status :: 5 - Production/Stable",
@@ -32,7 +32,7 @@ keywords = [
     "engineering", "mechanics", "science", "numerical analysis", 
     "finite element method", "solid mechanics", "optimization"
 ]
-requires-python = ">=3.7, <3.11"
+requires-python = ">=3.8, <3.11"
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools.packages.find]

--- a/src/sigmaepsilon/core/__init__.py
+++ b/src/sigmaepsilon/core/__init__.py
@@ -3,20 +3,20 @@ from os.path import dirname, abspath
 import appdirs
 import warnings
 from typing import Optional
+from importlib.metadata import metadata
 
 from .wrapping import Wrapper
 from .typing import ishashable, issequence
 from .cp import classproperty
 from .infix import InfixOperator
 from .attr import attributor
-from .config import find_pyproject_toml, load_pyproject_config
+from .config import namespace_package_name
 
-pyproject_toml_path = find_pyproject_toml(dirname(abspath(__file__)), 10)
-project_config = load_pyproject_config(filepath=pyproject_toml_path, section="project")
-
-__pkg_name__ = project_config["name"]
-__version__ = project_config["version"]
-__description__ = project_config["description"]
+__pkg_name__ = namespace_package_name(dirname(abspath(__file__)), 10)
+__pkg_metadata__ = metadata(__pkg_name__)
+__version__ = __pkg_metadata__["version"]
+__description__ = __pkg_metadata__["summary"]
+del __pkg_metadata__
 
 # catch annoying numpy/vtk future warning:
 warnings.simplefilter(action="ignore", category=FutureWarning)

--- a/src/sigmaepsilon/core/config.py
+++ b/src/sigmaepsilon/core/config.py
@@ -76,3 +76,46 @@ def load_pyproject_config(
         config = config_toml
 
     return config
+
+
+def namespace_package_name(start_dir: str = None, max_depth: int = 10) -> str:
+    """
+    Returns the name of the SigmaEpsilon namespace package.
+    
+    Parameters
+    ----------
+    start_dir: str, Optional
+        The dictionary to start with. If not provided, the search starts in the current
+        working directory. Default is None.
+    max_depth: int, Optional
+        The maximum folderwise distance from the starting directory. If provided,
+        it must be an integer >= 0. Default is 10.
+    """
+    if start_dir is None:
+        start_dir = os.getcwd()
+
+    if not isinstance(start_dir, str):
+        raise TypeError("start_dir must be a string")
+    
+    current_dir = start_dir
+    depth = 0
+
+    if not isinstance(max_depth, int):
+        raise TypeError("max_depth must be an integer")
+
+    if not max_depth >= 0:
+        raise ValueError("max_depth must be a positive integer")
+
+    while depth <= max_depth:        
+        parent_dir_path, current_dir_name = os.path.split(current_dir)
+        parent_dir_name = os.path.split(parent_dir_path)[-1]
+        
+        if os.path.isdir(current_dir) and parent_dir_name=="sigmaepsilon":
+            return ".".join([parent_dir_name, current_dir_name])
+
+        parent_dir = os.path.dirname(current_dir)
+
+        current_dir = parent_dir
+        depth += 1
+
+    return None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,13 @@
 # -*- coding: utf-8 -*-
 import unittest, os
+from os.path import dirname, abspath
 
-from sigmaepsilon.core.config import find_pyproject_toml, load_pyproject_config
+import sigmaepsilon.core as sc
+from sigmaepsilon.core.config import (
+    find_pyproject_toml,
+    load_pyproject_config,
+    namespace_package_name,
+)
 from sigmaepsilon.core.testing import SigmaEpsilonTestCase
 
 
@@ -11,15 +17,13 @@ class TestConfig(SigmaEpsilonTestCase):
         pyproject_toml_path = find_pyproject_toml(start_dir, max_depth=0)
         config = load_pyproject_config(filepath=pyproject_toml_path)
         self.assertTrue(isinstance(config, dict))
-        config = load_pyproject_config(
-            filepath=pyproject_toml_path, section="project"
-        )
+        config = load_pyproject_config(filepath=pyproject_toml_path, section="project")
         self.assertTrue(isinstance(config, dict))
         config = load_pyproject_config(
             filepath=pyproject_toml_path, section=["project", "build-system"]
         )
         self.assertTrue(isinstance(config, list))
-        self.assertTrue(len(config)==2)
+        self.assertTrue(len(config) == 2)
         self.assertTrue(isinstance(config[0], dict))
         self.assertTrue(isinstance(config[1], dict))
         self.assertFailsProperly(
@@ -28,10 +32,20 @@ class TestConfig(SigmaEpsilonTestCase):
         self.assertFailsProperly(
             ValueError, find_pyproject_toml, start_dir, max_depth=-1
         )
+        self.assertFailsProperly(TypeError, find_pyproject_toml, 1, max_depth=-1)
+        
+        config = load_pyproject_config(filepath=pyproject_toml_path, section="project")
+        package_name = namespace_package_name(dirname(abspath(sc.__file__)), 10)
+        self.assertEqual(package_name, config["name"])
+        
         self.assertFailsProperly(
-            TypeError, find_pyproject_toml, 1, max_depth=-1
+            TypeError, namespace_package_name, start_dir, max_depth="0"
         )
-       
+        self.assertFailsProperly(
+            ValueError, namespace_package_name, start_dir, max_depth=-1
+        )
+        self.assertFailsProperly(TypeError, namespace_package_name, 1, max_depth=-1)
+        
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Changed the way metadata is extracted. The present implementation does not depend on the presence of a pyproject.toml file, which was a bug.